### PR TITLE
pinning versions of apt-get upgrades to known/min levels

### DIFF
--- a/templates/k8s-jobs.yml
+++ b/templates/k8s-jobs.yml
@@ -10,7 +10,7 @@ instance_groups:
         #!/bin/bash
         apt-get update
         apt-get -y remove rsync vim-tiny vim-gui-common python2.7-minimal python3.5-minimal
-        apt-get -y upgrade vim libarchive13 libsqlite3-0 sqlite3 libicu55 python2.7 python3.5
+        apt-get -y upgrade vim=2:7.4.1689-3ubuntu1.4 libarchive13=3.1.2-11ubuntu0.16.04.8 libsqlite3-0=3.11.0-1ubuntu1.4 sqlite3=3.11.0-1ubuntu1.4 libicu55=55.1-7ubuntu0.5 python2.7=2.7.12-1ubuntu0~16.04.11 python3.5=3.5.2-2ubuntu0~16.04.10
   instances: 3
   vm_type: kubernetes_consul
   disk_type: kubernetes


### PR DESCRIPTION
## Changes proposed in this pull request:
- pinning apt-get releases to versions required to resolve CVEs without going to newer versions that could introduce other issues

   - Apply proper fix for https://usn.ubuntu.com/4309-1/ -- vim
   - Apply fix for https://usn.ubuntu.com/4293-1/ -- libarchive
   - Apply fix for https://usn.ubuntu.com/4298-1/ -- sqlite
   - Apply fix for https://usn.ubuntu.com/4305-1/ -- ICU (international components for unicode)
   - Apply fix for https://usn.ubuntu.com/4333-1/ -- python

## security considerations
Enhances security by applying patches
