### PR TITLE
fixing min version of sqllite and re-format pre-start to allow failure

### DIFF
--- a/templates/k8s-jobs.yml
+++ b/templates/k8s-jobs.yml
@@ -12,16 +12,16 @@ instance_groups:
         apt-get -y remove \
           rsync vim-tiny vim-gui-common python2.7-minimal python3.5-minimal \
           linux-firmware `# USN-4351-1`
-        apt-get -y upgrade vim=2:7.4.1689-3ubuntu1.4 \
-          libarchive13=3.1.2-11ubuntu0.16.04.8 \
-          libsqlite3-0=3.11.0-1ubuntu1.4 \
-          sqlite3=3.11.0-1ubuntu1.4 \
-          libicu55=55.1-7ubuntu0.5 \
-          python2.7=2.7.12-1ubuntu0~16.04.11 \
-          python3.5=3.5.2-2ubuntu0~16.04.10 \
-          file=1:5.25-2ubuntu1.4 `# USN-3911-2` \
-          libmagic1=1:5.25-2ubuntu1.4 `# USN-3911-2` \
-          apt=1.2.32ubuntu0.1 `# USN-4359-1`
+        apt-get -y upgrade vim=2:7.4.1689-3ubuntu1.4
+        apt-get -y upgrade libarchive13=3.1.2-11ubuntu0.16.04.8
+        apt-get -y upgrade libsqlite3-0=3.11.0-1ubuntu1.5 sqlite3=3.11.0-1ubuntu1.5
+        apt-get -y upgrade libicu55=55.1-7ubuntu0.5
+        apt-get -y upgrade python2.7=2.7.12-1ubuntu0~16.04.11
+        apt-get -y upgrade python3.5=3.5.2-2ubuntu0~16.04.10
+        apt-get -y upgrade file=1:5.25-2ubuntu1.4 `# USN-3911-2`
+        apt-get -y upgrade libmagic1=1:5.25-2ubuntu1.4 `# USN-3911-2`
+        apt-get -y upgrade apt=1.2.32ubuntu0.1 `# USN-4359-1`
+        /bin/true
   instances: 3
   vm_type: kubernetes_consul
   disk_type: kubernetes


### PR DESCRIPTION
## Changes proposed in this pull request:
- Move `sqllite` and `libsqlite3-0` to use min version `3.11.0-1ubuntu1.5` as `3.11.0-1ubuntu1.4` is longer available 
- Changed script to install 1 item at a time to lessen failures
- Added `/bin/true` to allow the script to exit clean if it fails to not hold up pre-start and allow VM to come up

## security considerations
With the force clean exist on the script we now relay on nessus to catch script failures and if versions are no longer available 
