### PR TITLE
Bumped curls to .16

### DIFF
--- a/templates/k8s-jobs.yml
+++ b/templates/k8s-jobs.yml
@@ -25,7 +25,7 @@ instance_groups:
         apt-get -y upgrade dbus=1.10.6-1ubuntu3.6
         apt-get -y upgrade intel-microcode=3.20200609.0ubuntu0.16.04.1
         apt-get -y upgrade libc6=2.23-0ubuntu11.2
-        apt-get -y upgrade curl=7.47.0-1ubuntu2.15 libcurl3-gnutls=7.47.0-1ubuntu2.15 libcurl3=7.47.0-1ubuntu2.15
+        apt-get -y upgrade curl=7.47.0-1ubuntu2.16 libcurl3-gnutls=7.47.0-1ubuntu2.16 libcurl3=7.47.0-1ubuntu2.16  `# USN-4466-1`
         apt-get -y upgrade libdbus-1-3=1.10.6-1ubuntu3.6
         apt-get -y upgrade vim=2:7.4.1689-3ubuntu1.4
         apt-get -y upgrade libarchive13=3.1.2-11ubuntu0.16.04.8


### PR DESCRIPTION
## Changes proposed in this pull request:
- Bumped curls from 7.47.0-1ubuntu2.15 to 7.47.0-1ubuntu2.16 for USN-4466-1

## security considerations
None, making things better :)