### PR TITLE
Adding in mitigation for CG222

### DIFF
--- a/templates/k8s-jobs.yml
+++ b/templates/k8s-jobs.yml
@@ -42,7 +42,6 @@ instance_groups:
         apt-get -y upgrade libssl1.0.0=1.0.2g-1ubuntu4.17 `# USN-4504-1`
         apt-get -y upgrade     openssl=1.0.2g-1ubuntu4.17 `# USN-4504-1`
         /lib/systemd/systemd-sysv-install disable rsync `# rsync needs to be disabled even though it was removed.`
-        cat > /etc/apt/apt.conf.d/cloud-gov <<EOF
         #Script to mitigate CVE-2020-11935 from CG222
         minute=$((RANDOM%60))
         hour=$((RANDOM%8))

--- a/templates/k8s-jobs.yml
+++ b/templates/k8s-jobs.yml
@@ -42,6 +42,17 @@ instance_groups:
         apt-get -y upgrade libssl1.0.0=1.0.2g-1ubuntu4.17 `# USN-4504-1`
         apt-get -y upgrade     openssl=1.0.2g-1ubuntu4.17 `# USN-4504-1`
         /lib/systemd/systemd-sysv-install disable rsync `# rsync needs to be disabled even though it was removed.`
+        cat > /etc/apt/apt.conf.d/cloud-gov <<EOF
+        #Script to mitigate CVE-2020-11935 from CG222
+        minute=$((RANDOM%60))
+        hour=$((RANDOM%8))
+        cat > /etc/cron.d/k8s-flush.sh <<EOF
+        #!/bin/bash
+        echo 2 | sudo tee /proc/sys/vm/drop_caches
+        EOF
+        chmod 0700 /etc/cron.d/k8s-flush.sh
+        chown "root:" /etc/cron.d/k8s-flush.sh
+        ! (cat /etc/crontab | grep -q "k8s-flush.sh") && (echo "$minute $hour * * * root /etc/cron.d/k8s-flush.sh" >> /etc/crontab)
         /bin/true
   instances: 3
   vm_type: kubernetes_consul


### PR DESCRIPTION
## Changes proposed in this pull request:
- Adjust os-conf release script to mitigate CVE-2020-11935 for CG222
- Adds a script to `/etc/cron.d` that does a cache flush
- New script is added to crontab at a random minute and random hour between 01-08 UTC (21-04 EST) to flush the cache
- The random is to spread the impact across the k8s cluster 

## security considerations
- Should resolve CVE-2020-11935 for CG222 since we can't patch nor move the current stemcell any higher
